### PR TITLE
将BaseFactory中的create函数变为纯虚函数

### DIFF
--- a/include/reflect/reflect.h
+++ b/include/reflect/reflect.h
@@ -42,9 +42,7 @@ public:
    Create a object of base class
    @return pointer to new object
    */
-  virtual T* create() const {
-    return new T();
-  };
+  virtual T* create() const = 0;
 };
 
 /*!


### PR DESCRIPTION
BaseFactory中的模板变量T可能是一个无法实例化的基类，因此可能无法执行"return new T();"。